### PR TITLE
Add shipping override example to the node plugin

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,6 @@
 const bodyParser = require('body-parser');
 const express = require('express');
 const request = require('request-promise');
-
 const verify_signature = require('./middleware').verify_signature;
 
 const app = express();
@@ -107,6 +106,11 @@ app.post('/cashier/event', verify_signature, (req, res) => {
 
 app.get('/settings', verify_signature, (req, res) => {
     const settings = handleSettingsPage(req);
+    const token = req.body.token;
+
+    if (typeof token === 'undefined') {
+        res.status(400).send('Error: "token" is required');
+    }
 
     res.send({
         token: req.token,
@@ -116,10 +120,31 @@ app.get('/settings', verify_signature, (req, res) => {
 
 app.post('/settings', verify_signature, (req, res) => {
     const settings = handleReceiveUserSettings(req);
+    const token = req.body.token;
+
+    if (typeof token === 'undefined') {
+        res.status(400).send('Error: "token" is required');
+    }
 
     res.send({
         token: req.token,
         settings: settings,
+    });
+});
+
+app.post('/shipping', verify_signature, (req, res) => {
+    res.send({
+        name: 'My Custom Shipping Override',
+        rates: [
+            {
+                line_text: 'EXTERNAL ECONOMY SHIPPING 5-7 BUSINESS DAYS',
+                value: 11.5,
+            },
+            {
+                line_text: 'EXTERNAL SHIPPING SOURCE OVERNIGHT EXPRESS',
+                value: 15.5,
+            },
+        ],
     });
 });
 
@@ -193,6 +218,12 @@ function handleInitializeCheckout(req) {
                 position: 'payment_gateway',
                 text: 'Pay via the honor system',
                 click_hook: 'add_payment',
+            },
+        },
+        {
+            type: 'OVERRIDE_SHIPPING',
+            data: {
+                url: process.env.APP_URL + '/shipping',
             },
         },
     ];

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -57,6 +57,51 @@ describe('app', () => {
         });
     });
 
+    describe('GET /settings', () => {
+        it('responds with status 400 when "token" is missing', () => {
+            return request(app)
+                .get('/settings?platform=shopify&shop=example.myshopify.com')
+                .expect(400);
+        });
+
+        it('responds with success', () => {
+            const token = 'fsdf34543rsdf232f';
+
+            return request(app)
+                .get('/settings')
+                .send({
+                    token: 'fsdf34543rsdf232f',
+                })
+                .expect(200)
+                .expect(function(res) {
+                    res.body.token = token;
+                });
+        });
+    });
+
+    describe('POST /settings', () => {
+        it('responds with status 400 when "token" is missing', () => {
+            return request(app)
+                .post('/settings')
+                .send()
+                .expect(400);
+        });
+
+        it('responds with success', () => {
+            const token = 'fsdf34543rsdf232f';
+
+            return request(app)
+                .post('/settings')
+                .send({
+                    token: 'fsdf34543rsdf232f',
+                })
+                .expect(200)
+                .expect(function(res) {
+                    res.body.token = token;
+                });
+        });
+    });
+
     describe('GET /oauth/authorize', () => {
         it('responds with status 400 when "code" is missing', () => {
             return request(app)
@@ -230,6 +275,12 @@ describe('app', () => {
                                 position: 'payment_gateway',
                                 text: 'Pay via the honor system',
                                 click_hook: 'add_payment',
+                            },
+                        },
+                        {
+                            type: 'OVERRIDE_SHIPPING',
+                            data: {
+                                url: process.env.APP_URL + '/shipping',
                             },
                         },
                     ],


### PR DESCRIPTION
There were two settings endpoints, one a get and one a post, the only valid one is a get.

Added shipping override to `handleInitializeCheckout` and an endpoint to deliver rates at `/shipping`